### PR TITLE
rename to onediff

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ python server/main.py --reload --pipeline txt2imgLoraSDXL
 * `--debug`: Print Inference time  
 * `--compel`: Compel option  
 * `--sfast`: Enable Stable Fast   
-* `--oneflow`: Enable OneFlow    
+* `--onediff`: Enable OneDiff
 
 If you run using `bash build-run.sh` you can set `PIPELINE` variables to choose the pipeline you want to run
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ xformers; sys_platform != 'darwin' or platform_machine != 'arm64'
 markdown2
 stable_fast @ https://github.com/chengzeyi/stable-fast/releases/download/v0.0.15.post1/stable_fast-0.0.15.post1+torch211cu121-cp310-cp310-manylinux2014_x86_64.whl
 oneflow @ https://oneflow-pro.oss-cn-beijing.aliyuncs.com/branch/community/cu121/794a56cc787217f46b21f5cbc84f65295664b82c/oneflow-0.9.1%2Bcu121.git.794a56c-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-git+https://github.com/Oneflow-Inc/onediff.git@main#egg=onediff
+git+https://github.com/siliconflow/onediff.git@main#egg=onediff

--- a/server/config.py
+++ b/server/config.py
@@ -16,7 +16,7 @@ class Args(NamedTuple):
     ssl_certfile: str
     ssl_keyfile: str
     sfast: bool
-    oneflow: bool = False
+    onediff: bool = False
     compel: bool = False
     debug: bool = False
 
@@ -112,10 +112,10 @@ parser.add_argument(
     help="Enable Stable Fast",
 )
 parser.add_argument(
-    "--oneflow",
+    "--onediff",
     action="store_true",
     default=False,
-    help="Enable OneFlow",
+    help="Enable OneDiff",
 )
 parser.set_defaults(taesd=USE_TAESD)
 

--- a/server/pipelines/controlnet.py
+++ b/server/pipelines/controlnet.py
@@ -187,8 +187,8 @@ class Pipeline:
             config.enable_cuda_graph = True
             self.pipe = compile(self.pipe, config=config)
 
-        if args.oneflow:
-            print("\nRunning oneflow compile\n")
+        if args.onediff:
+            print("\nRunning onediff compile\n")
             from onediff.infer_compiler import oneflow_compile
 
             self.pipe.unet = oneflow_compile(self.pipe.unet)

--- a/server/pipelines/controlnetSDTurbo.py
+++ b/server/pipelines/controlnetSDTurbo.py
@@ -194,8 +194,8 @@ class Pipeline:
             config.enable_cuda_graph = True
             self.pipe = compile(self.pipe, config=config)
 
-        if args.oneflow:
-            print("\nRunning oneflow compile\n")
+        if args.onediff:
+            print("\nRunning onediff compile\n")
             from onediff.infer_compiler import oneflow_compile
 
             self.pipe.unet = oneflow_compile(self.pipe.unet)

--- a/server/pipelines/img2imgSDTurbo.py
+++ b/server/pipelines/img2imgSDTurbo.py
@@ -121,8 +121,8 @@ class Pipeline:
             config.enable_cuda_graph = True
             self.pipe = compile(self.pipe, config=config)
 
-        if args.oneflow:
-            print("\nRunning oneflow compile\n")
+        if args.onediff:
+            print("\nRunning onediff compile\n")
             from onediff.infer_compiler import oneflow_compile
 
             self.pipe.unet = oneflow_compile(self.pipe.unet)


### PR DESCRIPTION
We have 
- use onediff as the lib name and continue the dev;
- moved the development to new org siliconflow;
so rename to onediff and siliconflow.

@radames 